### PR TITLE
[Backend] Le metriche ora sono aggregate per route template

### DIFF
--- a/backend/internal/infra/metrics/module.go
+++ b/backend/internal/infra/metrics/module.go
@@ -13,6 +13,12 @@ var Module = fx.Module(
 
 func RegisterPrometheus(router *gin.Engine) {
 	p := ginprometheus.NewPrometheus("gin")
+	p.ReqCntURLLabelMappingFn = func(ctx *gin.Context) string {
+		if path := ctx.FullPath(); path != "" {
+			return path
+		}
+		return ctx.Request.URL.Path
+	}
 
 	p.Use(router)
 }


### PR DESCRIPTION
Precedentemente le chiamate ad uno stesso endpoint venivano considerate diverse in quanto aventi (ovviamente) sensor-id e tenant-id diversi.

closes #126