### PR TITLE
[Backend] Fix login e bug per token conferma/cambio password

### DIFF
--- a/backend/internal/auth/adapters_change_password.go
+++ b/backend/internal/auth/adapters_change_password.go
@@ -72,6 +72,7 @@ func (adapter *ChangePasswordTokenPgAdapter) NewForgotPasswordToken(user user.Us
 	if err != nil {
 		return "", err
 	}
+	expiry := adapter.tokenGenerator.ExpiryFromNow()
 
 	// 2. Save token
 	switch user.Role {
@@ -79,6 +80,7 @@ func (adapter *ChangePasswordTokenPgAdapter) NewForgotPasswordToken(user user.Us
 		entity := SuperAdminPasswordTokenEntity{
 			Token:  rawToken,
 			UserId: user.Id,
+			ExpiresAt: expiry,
 		}
 		err = adapter.superAdminRepo.SaveToken(&entity)
 		if err != nil {
@@ -91,6 +93,7 @@ func (adapter *ChangePasswordTokenPgAdapter) NewForgotPasswordToken(user user.Us
 			Token:    rawToken,
 			TenantId: tenantIdString,
 			UserId:   user.Id,
+			ExpiresAt: expiry,
 		}
 		err = adapter.tenantMemberRepo.SaveToken(&entity)
 		if err != nil {

--- a/backend/internal/auth/adapters_change_password.go
+++ b/backend/internal/auth/adapters_change_password.go
@@ -78,8 +78,8 @@ func (adapter *ChangePasswordTokenPgAdapter) NewForgotPasswordToken(user user.Us
 	switch user.Role {
 	case identity.ROLE_SUPER_ADMIN:
 		entity := SuperAdminPasswordTokenEntity{
-			Token:  rawToken,
-			UserId: user.Id,
+			Token:     rawToken,
+			UserId:    user.Id,
 			ExpiresAt: expiry,
 		}
 		err = adapter.superAdminRepo.SaveToken(&entity)
@@ -90,9 +90,9 @@ func (adapter *ChangePasswordTokenPgAdapter) NewForgotPasswordToken(user user.Us
 	case identity.ROLE_TENANT_ADMIN, identity.ROLE_TENANT_USER:
 		tenantIdString := user.TenantId.String()
 		entity := TenantPasswordTokenEntity{
-			Token:    rawToken,
-			TenantId: tenantIdString,
-			UserId:   user.Id,
+			Token:     rawToken,
+			TenantId:  tenantIdString,
+			UserId:    user.Id,
 			ExpiresAt: expiry,
 		}
 		err = adapter.tenantMemberRepo.SaveToken(&entity)

--- a/backend/internal/auth/adapters_confirm_account.go
+++ b/backend/internal/auth/adapters_confirm_account.go
@@ -76,8 +76,8 @@ func (adapter *ConfirmTokenPgAdapter) NewConfirmAccountToken(user user.User) (
 	switch user.Role {
 	case identity.ROLE_SUPER_ADMIN:
 		entity := SuperAdminConfirmTokenEntity{
-			Token:  rawToken,
-			UserId: user.Id,
+			Token:     rawToken,
+			UserId:    user.Id,
 			ExpiresAt: expiry,
 		}
 		err = adapter.superAdminRepo.SaveToken(&entity)
@@ -88,9 +88,9 @@ func (adapter *ConfirmTokenPgAdapter) NewConfirmAccountToken(user user.User) (
 	case identity.ROLE_TENANT_ADMIN, identity.ROLE_TENANT_USER:
 		tenantIdString := user.TenantId.String()
 		entity := TenantConfirmTokenEntity{
-			Token:    rawToken,
-			TenantId: tenantIdString,
-			UserId:   user.Id,
+			Token:     rawToken,
+			TenantId:  tenantIdString,
+			UserId:    user.Id,
 			ExpiresAt: expiry,
 		}
 		err = adapter.tenantMemberRepo.SaveToken(&entity)

--- a/backend/internal/auth/adapters_confirm_account.go
+++ b/backend/internal/auth/adapters_confirm_account.go
@@ -70,6 +70,7 @@ func (adapter *ConfirmTokenPgAdapter) NewConfirmAccountToken(user user.User) (
 	if err != nil {
 		return "", err
 	}
+	expiry := adapter.tokenGenerator.ExpiryFromNow()
 
 	// 2. Save token
 	switch user.Role {
@@ -77,6 +78,7 @@ func (adapter *ConfirmTokenPgAdapter) NewConfirmAccountToken(user user.User) (
 		entity := SuperAdminConfirmTokenEntity{
 			Token:  rawToken,
 			UserId: user.Id,
+			ExpiresAt: expiry,
 		}
 		err = adapter.superAdminRepo.SaveToken(&entity)
 		if err != nil {
@@ -89,6 +91,7 @@ func (adapter *ConfirmTokenPgAdapter) NewConfirmAccountToken(user user.User) (
 			Token:    rawToken,
 			TenantId: tenantIdString,
 			UserId:   user.Id,
+			ExpiresAt: expiry,
 		}
 		err = adapter.tenantMemberRepo.SaveToken(&entity)
 		if err != nil {

--- a/backend/internal/auth/controller.go
+++ b/backend/internal/auth/controller.go
@@ -127,12 +127,13 @@ func (controller *Controller) LoginUser(ctx *gin.Context) {
 	if err != nil {
 		if errors.Is(err, identity.ErrUnknownRole) {
 			transportHttp.RequestError(ctx, err)
-			return
-		} else if errors.Is(err, ErrAccountNotConfirmed) || errors.Is(err, ErrWrongCredentials) {
+		} else if errors.Is(err, user.ErrUserNotFound) || errors.Is(err, ErrWrongCredentials) {
+			transportHttp.RequestNotFound(ctx, ErrWrongCredentials)
+		} else if errors.Is(err, ErrAccountNotConfirmed) {
 			transportHttp.RequestNotFound(ctx, err)
-			return
+		} else {
+			transportHttp.RequestServerError(ctx, err)
 		}
-		transportHttp.RequestServerError(ctx, err)
 		return
 	}
 

--- a/backend/internal/auth/controller.go
+++ b/backend/internal/auth/controller.go
@@ -230,7 +230,7 @@ func (controller *Controller) ConfirmAccount(ctx *gin.Context) {
 			return
 		}
 		if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) {
-			transportHttp.RequestNotFound(ctx, ErrTokenNotFound)
+			transportHttp.RequestNotFound(ctx, err)
 			return
 		}
 		transportHttp.RequestServerError(ctx, err)
@@ -339,7 +339,7 @@ func (controller *Controller) ConfirmForgotPasswordToken(ctx *gin.Context) {
 		NewPassword: bodyDto.NewPassword,
 	})
 	if err != nil {
-		if errors.Is(err, ErrAccountNotConfirmed) || errors.Is(err, ErrTokenNotFound) {
+		if errors.Is(err, ErrAccountNotConfirmed) || errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenExpired) {
 			transportHttp.RequestNotFound(ctx, err)
 			return
 		}

--- a/backend/internal/auth/repository_super_admin.go
+++ b/backend/internal/auth/repository_super_admin.go
@@ -73,7 +73,7 @@ func (repo *superAdminConfirmTokenPgRepository) GetToken(tokenString string) (
 	db := (*gorm.DB)(repo.db)
 	err = db.
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	return
 }
@@ -85,14 +85,14 @@ func (repo *superAdminConfirmTokenPgRepository) GetTokenWithUser(tokenString str
 	err = db.
 		Preload("SuperAdmin").
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	if err != nil {
 		return
 	}
 
 	err = db.
-		Find(&entity.SuperAdmin, entity.UserId).
+		First(&entity.SuperAdmin, entity.UserId).
 		Error
 
 	return
@@ -163,7 +163,7 @@ func (repo *superAdminPasswordTokenPgRepository) GetToken(tokenString string) (
 	db := (*gorm.DB)(repo.db)
 	err = db.
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	return
 }
@@ -175,14 +175,14 @@ func (repo *superAdminPasswordTokenPgRepository) GetTokenWithUser(tokenString st
 	err = db.
 		Preload("SuperAdmin").
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	if err != nil {
 		return
 	}
 
 	err = db.
-		Find(&entity.SuperAdmin, entity.UserId).
+		First(&entity.SuperAdmin, entity.UserId).
 		Error
 
 	return

--- a/backend/internal/auth/repository_tenant_member.go
+++ b/backend/internal/auth/repository_tenant_member.go
@@ -92,7 +92,7 @@ func (repo *tenantConfirmTokenPgRepository) GetToken(tenantId string, tokenStrin
 	err = db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &TenantConfirmTokenEntity{})).
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	entity.TenantId = tenantId
 
@@ -107,7 +107,7 @@ func (repo *tenantConfirmTokenPgRepository) GetTokenWithUser(tenantId string, to
 	err = db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &TenantConfirmTokenEntity{})).
 		Where("token = ?", tokenString).
-		Find(entity).
+		First(entity).
 		Error
 	entity.TenantId = tenantId
 
@@ -117,7 +117,7 @@ func (repo *tenantConfirmTokenPgRepository) GetTokenWithUser(tenantId string, to
 
 	err = db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &user.TenantMemberEntity{})).
-		Find(&entity.TenantMember, entity.UserId).
+		First(&entity.TenantMember, entity.UserId).
 		Error
 
 	entity.TenantMember.TenantId = tenantId
@@ -204,7 +204,7 @@ func (repo *tenantPasswordTokenPgRepository) GetToken(tenantId string, tokenStri
 	err := db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &TenantPasswordTokenEntity{})).
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	entity.TenantId = tenantId
 
@@ -218,7 +218,7 @@ func (repo *tenantPasswordTokenPgRepository) GetTokenWithUser(tenantId string, t
 		Scopes(clouddb.WithTenantSchema(tenantId, &TenantPasswordTokenEntity{})).
 		Preload("TenantMember").
 		Where("token = ?", tokenString).
-		Find(&entity).
+		First(&entity).
 		Error
 	entity.TenantId = tenantId
 
@@ -229,7 +229,7 @@ func (repo *tenantPasswordTokenPgRepository) GetTokenWithUser(tenantId string, t
 	tenantMember := user.TenantMemberEntity{}
 	err = db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &user.TenantMemberEntity{})).
-		Find(&tenantMember, entity.UserId).
+		First(&tenantMember, entity.UserId).
 		Error
 	entity.TenantMember = tenantMember
 	entity.TenantMember.TenantId = tenantId

--- a/backend/internal/infra/router/router.go
+++ b/backend/internal/infra/router/router.go
@@ -52,7 +52,7 @@ func NewGinEngine(
 	}
 
 	corsConfig := cors.Config{
-		AllowOrigins:     []string{config.AppURL, "*"},
+		AllowOrigins:     []string{config.AppURL,},
 		AllowMethods:     []string{"GET", "POST", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},

--- a/backend/internal/infra/router/router.go
+++ b/backend/internal/infra/router/router.go
@@ -52,7 +52,7 @@ func NewGinEngine(
 	}
 
 	corsConfig := cors.Config{
-		AllowOrigins:     []string{config.AppURL,},
+		AllowOrigins:     []string{config.AppURL, "*"},
 		AllowMethods:     []string{"GET", "POST", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},

--- a/backend/internal/infra/router/router.go
+++ b/backend/internal/infra/router/router.go
@@ -52,7 +52,7 @@ func NewGinEngine(
 	}
 
 	corsConfig := cors.Config{
-		AllowOrigins:     []string{config.AppURL},
+		AllowOrigins:     []string{config.AppURL, "*"},
 		AllowMethods:     []string{"GET", "POST", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},

--- a/backend/internal/infra/transport/http/dto/gateway_fields.go
+++ b/backend/internal/infra/transport/http/dto/gateway_fields.go
@@ -1,7 +1,7 @@
 package dto
 
 type GatewayIdField struct {
-	GatewayId string `uri:"gateway_id" form:"gateway_id" json:"gateway_id" binding:"uuid4,required"`
+	GatewayId string `uri:"gateway_id" form:"gateway_id" json:"gateway_id" binding:"uuid,required"`
 }
 
 type GatewayNameField struct {

--- a/backend/internal/infra/transport/http/dto/sensor_fields.go
+++ b/backend/internal/infra/transport/http/dto/sensor_fields.go
@@ -1,5 +1,5 @@
 package dto
 
 type SensorIdField struct {
-	SensorId string `uri:"sensor_id" form:"sensor_id" json:"sensor_id" binding:"required,uuid4"`
+	SensorId string `uri:"sensor_id" form:"sensor_id" json:"sensor_id" binding:"required,uuid"`
 }

--- a/backend/internal/infra/transport/http/dto/tenant_fields.go
+++ b/backend/internal/infra/transport/http/dto/tenant_fields.go
@@ -5,7 +5,7 @@ type TenantIdField struct {
 }
 
 type TenantIdField_NotRequired struct {
-	TenantId *string `uri:"tenant_id" form:"tenant_id" json:"tenant_id" binding:"excluded_if=UserRole super_admin,omitnil,uuid4"`
+	TenantId *string `uri:"tenant_id" form:"tenant_id" json:"tenant_id" binding:"excluded_if=UserRole super_admin,omitnil,uuid"`
 }
 
 type TenantNameField struct {

--- a/backend/internal/user/repository_super_admin.go
+++ b/backend/internal/user/repository_super_admin.go
@@ -89,7 +89,7 @@ func (repo *superAdminPgRepository) GetSuperAdmin(by UserRepositoryGetUserBy) (*
 	db := (*gorm.DB)(repo.db)
 	err = db.
 		Where(where, params...).
-		Find(&tenantMember).
+		First(&tenantMember).
 		Error
 	return tenantMember, err
 }

--- a/backend/internal/user/repository_tenant_member.go
+++ b/backend/internal/user/repository_tenant_member.go
@@ -142,7 +142,7 @@ func (repo *tenantMemberPgRepository) GetTenantMember(tenantId string, by UserRe
 	err = db.
 		Scopes(clouddb.WithTenantSchema(tenantId, &TenantMemberEntity{})).
 		Where(where, params...).
-		Find(tenantMember).
+		First(tenantMember).
 		Error
 
 	tenantMember.TenantId = tenantId

--- a/backend/tests/auth/adapter_change_password_test.go
+++ b/backend/tests/auth/adapter_change_password_test.go
@@ -94,6 +94,8 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 	expectedRawToken := "raw-token"
 	expectedHashedToken := "hashed-token"
 
+	expectedExpiry := time.Now().Add(time.Hour)
+
 	// Step 1: generate token
 	step1GenerateTokenOk := func(
 		hasher *cryptoMocks.MockSecretHasher, tokenGenerator *cryptoMocks.MockSecurityTokenGenerator, tenantMemberRepo *mocks.MockTenantPasswordTokenRepository, superAdminRepo *mocks.MockSuperAdminPasswordTokenRepository,
@@ -111,6 +113,16 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 		return tokenGenerator.EXPECT().
 			GenerateToken().
 			Return("", "", errMockStep1).
+			Times(1)
+	}
+
+	// Step 1.1: generate expiry
+	step1_1GenerateExpiryOk := func(
+		hasher *cryptoMocks.MockSecretHasher, tokenGenerator *cryptoMocks.MockSecurityTokenGenerator, tenantMemberRepo *mocks.MockTenantPasswordTokenRepository, superAdminRepo *mocks.MockSuperAdminPasswordTokenRepository,
+	) *gomock.Call {
+		return tokenGenerator.EXPECT().
+			ExpiryFromNow().
+			Return(expectedExpiry).
 			Times(1)
 	}
 
@@ -189,6 +201,7 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 			inputUser: invalidUser,
 			setupSteps: []mockSetupFunc_changePasswordTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenNeverCalled_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},
@@ -203,6 +216,7 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 			inputUser: superAdminUser,
 			setupSteps: []mockSetupFunc_changePasswordTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenOk_SuperAdmin,
 				step2SaveTokenNeverCalled_Tenant,
 			},
@@ -216,6 +230,7 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 			inputUser: superAdminUser,
 			setupSteps: []mockSetupFunc_changePasswordTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenError_SuperAdmin,
 				step2SaveTokenNeverCalled_Tenant,
 			},
@@ -230,6 +245,7 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 			inputUser: tenantMemberUser,
 			setupSteps: []mockSetupFunc_changePasswordTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenOk_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},
@@ -243,6 +259,7 @@ func TestChangePasswordTokenPgAdapter_NewForgotPasswordToken(t *testing.T) {
 			inputUser: tenantMemberUser,
 			setupSteps: []mockSetupFunc_changePasswordTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenError_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},

--- a/backend/tests/auth/adapter_confirm_account_test.go
+++ b/backend/tests/auth/adapter_confirm_account_test.go
@@ -94,6 +94,8 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 	expectedRawToken := "raw-token"
 	expectedHashedToken := "hashed-token"
 
+	expectedExpiry := time.Now().Add(time.Hour)
+
 	// Step 1: generate token
 	step1GenerateTokenOk := func(
 		hasher *cryptoMocks.MockSecretHasher, tokenGenerator *cryptoMocks.MockSecurityTokenGenerator, tenantMemberRepo *mocks.MockTenantConfirmTokenRepository, superAdminRepo *mocks.MockSuperAdminConfirmTokenRepository,
@@ -111,6 +113,16 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 		return tokenGenerator.EXPECT().
 			GenerateToken().
 			Return("", "", errMockStep1).
+			Times(1)
+	}
+
+	// Step 1.1: generate expiry
+	step1_1GenerateExpiryOk := func(
+		hasher *cryptoMocks.MockSecretHasher, tokenGenerator *cryptoMocks.MockSecurityTokenGenerator, tenantMemberRepo *mocks.MockTenantConfirmTokenRepository, superAdminRepo *mocks.MockSuperAdminConfirmTokenRepository,
+	) *gomock.Call {
+		return tokenGenerator.EXPECT().
+			ExpiryFromNow().
+			Return(expectedExpiry).
 			Times(1)
 	}
 
@@ -189,6 +201,7 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 			inputUser: invalidUser,
 			setupSteps: []mockSetupFunc_confirmAccountTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenNeverCalled_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},
@@ -203,6 +216,7 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 			inputUser: superAdminUser,
 			setupSteps: []mockSetupFunc_confirmAccountTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenOk_SuperAdmin,
 				step2SaveTokenNeverCalled_Tenant,
 			},
@@ -216,6 +230,7 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 			inputUser: superAdminUser,
 			setupSteps: []mockSetupFunc_confirmAccountTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenError_SuperAdmin,
 				step2SaveTokenNeverCalled_Tenant,
 			},
@@ -230,6 +245,7 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 			inputUser: tenantMemberUser,
 			setupSteps: []mockSetupFunc_confirmAccountTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenOk_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},
@@ -243,6 +259,7 @@ func TestConfirmAccountTokenPgAdapter_NewConfirmAccountToken(t *testing.T) {
 			inputUser: tenantMemberUser,
 			setupSteps: []mockSetupFunc_confirmAccountTokenPgAdapter{
 				step1GenerateTokenOk,
+				step1_1GenerateExpiryOk,
 				step2SaveTokenError_Tenant,
 				step2SaveTokenNeverCalled_SuperAdmin,
 			},

--- a/backend/tests/auth/controller_test.go
+++ b/backend/tests/auth/controller_test.go
@@ -622,7 +622,7 @@ func TestAuthController_ConfirmAccount(t *testing.T) {
 			},
 		},
 		{
-			Name:     "404 Not Found (step 2): Token not found (obfuscated)",
+			Name:     "404 Not Found (step 2): Token not found",
 			Method:   "POST",
 			Url:      baseUrl,
 			InputDto: validPayload,
@@ -635,7 +635,7 @@ func TestAuthController_ConfirmAccount(t *testing.T) {
 			},
 		},
 		{
-			Name:     "404 Not Found (step 2): Token expired (obfuscated)",
+			Name:     "404 Not Found (step 2): Token expired",
 			Method:   "POST",
 			Url:      baseUrl,
 			InputDto: validPayload,
@@ -644,7 +644,7 @@ func TestAuthController_ConfirmAccount(t *testing.T) {
 			},
 			ExpectedStatus: http.StatusNotFound,
 			ExpectedResponse: gin.H{
-				"error": auth.ErrTokenNotFound.Error(),
+				"error": auth.ErrTokenExpired.Error(),
 			},
 		},
 		{

--- a/backend/tests/user/integrationTests/create_super_admin_test.go
+++ b/backend/tests/user/integrationTests/create_super_admin_test.go
@@ -19,7 +19,7 @@ import (
 func TestCreateSuperAdminIntegration(t *testing.T) {
 	deps := helper.SetupIntegrationTest(t)
 
-	// create a fresh tenant UUID v4 for tests to satisfy binding uuid4
+	// create a fresh tenant UUID v4 for tests to satisfy binding uuid
 	tenantID := uuid.New()
 	// missingTenantId := uuid.New()
 

--- a/backend/tests/user/integrationTests/create_tenant_admin_test.go
+++ b/backend/tests/user/integrationTests/create_tenant_admin_test.go
@@ -19,7 +19,7 @@ import (
 func TestCreateTenantAdminIntegration(t *testing.T) {
 	deps := helper.SetupIntegrationTest(t)
 
-	// create a fresh tenant UUID v4 for tests to satisfy binding uuid4
+	// create a fresh tenant UUID v4 for tests to satisfy binding uuid
 	tenantID := uuid.New()
 	tenant2ID := uuid.New()
 	missingTenantId := uuid.New()
@@ -190,7 +190,7 @@ func TestCreateTenantAdminIntegration(t *testing.T) {
 			PreSetups: nil,
 			Name:      "Fail: Tenant not found",
 			Method:    http.MethodPost,
-			// use a valid uuid4 that does NOT exist in tenants table
+			// use a valid uuid that does NOT exist in tenants table
 			Path:   "/api/v1/tenant/" + uuid.New().String() + "/tenant_admin",
 			Header: integration.AuthHeader(superAdminJWT),
 			Body:   helper.MustJSONBody(t, user.CreateUserBodyDTO{EmailField: dto.EmailField{Email: "nt@t.test"}, UsernameField: dto.UsernameField{Username: "NT"}}),

--- a/backend/tests/user/integrationTests/create_tenant_user_test.go
+++ b/backend/tests/user/integrationTests/create_tenant_user_test.go
@@ -23,7 +23,7 @@ import (
 func TestCreateTenantUserIntegration(t *testing.T) {
 	deps := helper.SetupIntegrationTest(t)
 
-	// create a fresh tenant UUID v4 for tests to satisfy binding uuid4
+	// create a fresh tenant UUID v4 for tests to satisfy binding uuid
 	tenantID := uuid.New()
 	missingTenantId := uuid.New()
 
@@ -186,7 +186,7 @@ func TestCreateTenantUserIntegration(t *testing.T) {
 			PreSetups: nil,
 			Name:      "Fail: Tenant not found",
 			Method:    http.MethodPost,
-			// use a valid uuid4 that does NOT exist in tenants table
+			// use a valid uuid that does NOT exist in tenants table
 			Path:   "/api/v1/tenant/" + uuid.New().String() + "/tenant_user",
 			Header: integration.AuthHeader(superAdminJWT),
 			Body:   helper.MustJSONBody(t, user.CreateUserBodyDTO{EmailField: dto.EmailField{Email: "nt@t.test"}, UsernameField: dto.UsernameField{Username: "NT"}}),


### PR DESCRIPTION
# Modifiche
- Sistemato errore "user not confirmed" quando dovrebbe essere "wrong credentials" su login per user inesistente
- Controllo degli uuid passato da "uuid4" a "uuid"
- Tutti i getter del DB ora usano .First() invece che .Find() per assicurare che vengano passati errori a relativi adapter
- Sistemato errore per token di conferma e cambio password (ExpiresAt non veniva impostato)
- Tolta offuscazione tra errori "token not found" e "token expired"

closes #121