### PR TITLE
[Backend] Fix logica gestione Tenant Admin

### DIFF
--- a/backend/internal/shared/config/config.go
+++ b/backend/internal/shared/config/config.go
@@ -125,7 +125,7 @@ func ReadConfigFromEnv(log *zap.Logger) (*Config, error) {
 			missingFields = append(missingFields, envKey)
 			continue
 		}
-		
+
 		// Inserisci in envDict se NON trovo già
 		if !inEnvFile {
 			envDict[envKey] = value

--- a/backend/internal/user/service_create.go
+++ b/backend/internal/user/service_create.go
@@ -3,6 +3,7 @@ package user
 import (
 	"backend/internal/shared/identity"
 	"backend/internal/tenant"
+
 	// "errors"
 
 	"github.com/google/uuid"
@@ -20,8 +21,6 @@ type SendConfirmAccountEmailPort interface {
 
 /*
 Servizio di creazione utente.
-
-Possibile miglioria: Validare l'input, non affidandosi a validazione in controller
 */
 type CreateUserService struct {
 	createUserPort          SaveUserPort
@@ -117,8 +116,8 @@ func (service *CreateUserService) CreateTenantAdmin(cmd CreateTenantAdminCommand
 
 	// Controlla autorizzazione tenant
 	// NOTA: rimosso static check per chiarezza
-	superAdminAccess := cmd.Requester.IsSuperAdmin() && tenantFound.CanImpersonate //nolint:staticcheck
-	if !superAdminAccess && !cmd.CanTenantAdminAccess(cmd.TenantId) {              //nolint:staticcheck
+	superAdminAccess := cmd.Requester.IsSuperAdmin()                  //nolint:staticcheck
+	if !superAdminAccess && !cmd.CanTenantAdminAccess(cmd.TenantId) { //nolint:staticcheck
 		return User{}, identity.ErrUnauthorizedAccess
 	}
 

--- a/backend/internal/user/service_delete.go
+++ b/backend/internal/user/service_delete.go
@@ -8,8 +8,6 @@ import (
 // Delete User ====================================================================================
 /*
 	Servizio di eliminazione utente.
-
-	Possibile miglioria: Validare l'input, non affidandosi a validazione in controller
 */
 type DeleteUserService struct {
 	deleteUserPort DeleteUserPort
@@ -77,8 +75,8 @@ func (service *DeleteUserService) DeleteTenantAdmin(cmd DeleteTenantAdminCommand
 
 	// Controlla autorizzazione tenant
 	// NOTA: rimosso static check per chiarezza
-	superAdminAccess := cmd.Requester.IsSuperAdmin() && tenantFound.CanImpersonate //nolint:staticcheck
-	if !superAdminAccess && !cmd.Requester.CanTenantAdminAccess(cmd.TenantId) {    //nolint:staticcheck
+	superAdminAccess := cmd.Requester.IsSuperAdmin()                            //nolint:staticcheck
+	if !superAdminAccess && !cmd.Requester.CanTenantAdminAccess(cmd.TenantId) { //nolint:staticcheck
 		return User{}, identity.ErrUnauthorizedAccess
 	}
 

--- a/backend/internal/user/service_get.go
+++ b/backend/internal/user/service_get.go
@@ -7,8 +7,6 @@ import (
 
 /*
 Servizio usato per ottenere informazioni su uno o più utenti.
-
-Possibile miglioria: Validare l'input, non affidandosi a validazione in controller
 */
 type GetUserService struct {
 	getUserPort   GetUserPort
@@ -80,8 +78,8 @@ func (service *GetUserService) GetTenantAdmin(cmd GetTenantAdminCommand) (User, 
 
 	// Controlla autorizzazione
 	// NOTA: rimosso static check per chiarezza
-	superAdminAccess := cmd.Requester.IsSuperAdmin() && tenantFound.CanImpersonate //nolint:staticcheck
-	tenantAdminAccess := cmd.Requester.CanTenantAdminAccess(cmd.TenantId)          //nolint:staticcheck
+	superAdminAccess := cmd.Requester.IsSuperAdmin()                      //nolint:staticcheck
+	tenantAdminAccess := cmd.Requester.CanTenantAdminAccess(cmd.TenantId) //nolint:staticcheck
 	if !superAdminAccess && !tenantAdminAccess {
 		return User{}, identity.ErrUnauthorizedAccess
 	}
@@ -162,9 +160,9 @@ func (service *GetUserService) GetTenantAdminsByTenant(cmd GetTenantAdminsByTena
 
 	// 2) Controlla autorizzazione
 	// NOTA: rimosso static check per chiarezza
-	superAdminAccess := cmd.Requester.IsSuperAdmin() && tenantFound.CanImpersonate //nolint:staticcheck
-	tenantAdminAccess := cmd.Requester.CanTenantAdminAccess(cmd.TenantId)          //nolint:staticcheck
-	if !superAdminAccess && !tenantAdminAccess {                                   //nolint:staticcheck
+	superAdminAccess := cmd.Requester.IsSuperAdmin()                      //nolint:staticcheck
+	tenantAdminAccess := cmd.Requester.CanTenantAdminAccess(cmd.TenantId) //nolint:staticcheck
+	if !superAdminAccess && !tenantAdminAccess {                          //nolint:staticcheck
 		return nil, 0, identity.ErrUnauthorizedAccess
 	}
 

--- a/backend/tests/gateway/controller_commands_test.go
+++ b/backend/tests/gateway/controller_commands_test.go
@@ -305,4 +305,3 @@ func TestGatewayController_InterruptResumeResetReboot(t *testing.T) {
 		helper.ExecuteControllerTest(t, tc, "POST", "/gateway/:gateway_id/interrupt", controller.InterruptGateway)
 	})
 }
-

--- a/backend/tests/user/integrationTests/create_tenant_admin_test.go
+++ b/backend/tests/user/integrationTests/create_tenant_admin_test.go
@@ -80,21 +80,25 @@ func TestCreateTenantAdminIntegration(t *testing.T) {
 			},
 		},
 
-		// Super admin should be denied when tenant CanImpersonate == false
+		// Success: super admin with CanImpersonate = false
 		{
 			PreSetups: []helper.IntegrationTestPreSetup{
 				integration.PreSetupCreateTenant(tenantID, false),
 			},
-			Name:   "Fail: super admin cannot access tenant when CanImpersonate=false",
+			Name:   "Success: super admin when CanImpersonate=false",
 			Method: http.MethodPost,
 			Path:   "/api/v1/tenant/" + tenantID.String() + "/tenant_admin",
 			Header: integration.AuthHeader(superAdminJWT),
-			Body:   helper.MustJSONBody(t, user.CreateUserBodyDTO{EmailField: dto.EmailField{Email: "impersonation@t.test"}, UsernameField: dto.UsernameField{Username: "Imp"}}),
+			Body: helper.MustJSONBody(t, user.CreateUserBodyDTO{
+				EmailField:    dto.EmailField{Email: validEmail},
+				UsernameField: dto.UsernameField{Username: "Imp"},
+			}),
 
-			WantStatusCode:   http.StatusNotFound,
-			WantResponseBody: helper.ErrJsonString(tenant.ErrTenantNotFound),
+			WantStatusCode:   http.StatusOK,
+			WantResponseBody: validEmail, // Cerco email utente nel body
 			ResponseChecks: []helper.IntegrationTestCheck{
-				integration.CheckNoTenantMember("impersonation@t.test", tenantID.String()),
+				integration.CheckTenantMemberInserted(validEmail, tenantID.String()),
+				integration.CheckCountTenantConfirmAccountTokens(t, tenantID.String(), 1),
 			},
 
 			PostSetups: []helper.IntegrationTestPostSetup{

--- a/backend/tests/user/integrationTests/delete_tenant_admin_test.go
+++ b/backend/tests/user/integrationTests/delete_tenant_admin_test.go
@@ -84,6 +84,32 @@ func TestDeleteTenantAdminIntegration(t *testing.T) {
 	}
 	tests = append(tests, &tcSuccess)
 
+	// Success: Super admin when CanImpersonate=false
+	var tcSuperAdmin_NoImpersonate helper.IntegrationTestCase
+	tcSuperAdmin_NoImpersonate = helper.IntegrationTestCase{
+		PreSetups: []helper.IntegrationTestPreSetup{
+			integration.PreSetupCreateTenant(tenant1Id, false),
+			integration.PreSetupAddTenantAdmin(t, &tcSuperAdmin_NoImpersonate, existingTenantAdmin1Entity, true),
+			integration.PreSetupAddTenantAdmin(t, &tcSuperAdmin_NoImpersonate, existingTenantAdmin2Entity, true),
+		},
+		Name:   "Success: super admin when CanImpersonate=false",
+		Method: http.MethodDelete,
+		Header: integration.AuthHeader(superAdminJWT),
+		Body:   nil,
+
+		WantStatusCode:   http.StatusOK,
+		WantResponseBody: existingEmail2,
+		ResponseChecks: []helper.IntegrationTestCheck{
+			integration.CheckNoTenantMember(existingEmail2, tenant1Id.String()),
+		},
+		PostSetups: []helper.IntegrationTestPostSetup{
+			integration.PostSetupDeleteTenant(t, tenant1Id),
+			integration.PostSetupDeleteTenantMember(tenant1Id, existingEmail1),
+			integration.PostSetupDeleteTenantMember(tenant1Id, existingEmail2),
+		},
+	}
+	tests = append(tests, &tcSuperAdmin_NoImpersonate)
+
 	// Unauthorized no JWT
 	var tcNoJwt helper.IntegrationTestCase
 	tcNoJwt = helper.IntegrationTestCase{
@@ -205,32 +231,6 @@ func TestDeleteTenantAdminIntegration(t *testing.T) {
 		},
 	}
 	tests = append(tests, &tcWrongTenantId)
-
-	// Super admin denied when CanImpersonate=false
-	var tcSuperAdmin_NoImpersonate helper.IntegrationTestCase
-	tcSuperAdmin_NoImpersonate = helper.IntegrationTestCase{
-		PreSetups: []helper.IntegrationTestPreSetup{
-			integration.PreSetupCreateTenant(tenant1Id, false),
-			integration.PreSetupAddTenantAdmin(t, &tcSuperAdmin_NoImpersonate, existingTenantAdmin1Entity, true),
-			integration.PreSetupAddTenantAdmin(t, &tcSuperAdmin_NoImpersonate, existingTenantAdmin2Entity, true),
-		},
-		Name:   "Fail: super admin denied when CanImpersonate=false",
-		Method: http.MethodDelete,
-		Header: integration.AuthHeader(superAdminJWT),
-		Body:   nil,
-
-		WantStatusCode:   http.StatusNotFound,
-		WantResponseBody: helper.ErrJsonString(tenant.ErrTenantNotFound),
-		ResponseChecks: []helper.IntegrationTestCheck{
-			integration.CheckTenantMemberInserted(existingEmail1, tenant1Id.String()),
-		},
-		PostSetups: []helper.IntegrationTestPostSetup{
-			integration.PostSetupDeleteTenant(t, tenant1Id),
-			nil,
-			nil,
-		},
-	}
-	tests = append(tests, &tcSuperAdmin_NoImpersonate)
 
 	// User not found
 	tests = append(tests, &helper.IntegrationTestCase{

--- a/backend/tests/user/integrationTests/get_multiple_tenant_admins_test.go
+++ b/backend/tests/user/integrationTests/get_multiple_tenant_admins_test.go
@@ -105,6 +105,29 @@ func TestGetTenantAdminListIntegration(t *testing.T) {
 		PostSetups: []helper.IntegrationTestPostSetup{integration.PostSetupDeleteTenant(t, tenantId), nil, nil},
 	})
 
+	// Success: super admin (CanImpersonate=false)
+	tests = append(tests, &helper.IntegrationTestCase{
+		PreSetups: []helper.IntegrationTestPreSetup{
+			integration.PreSetupCreateTenant(tenantId, false),
+			integration.PreSetupAddTenantAdmin(t, nil, tenantAdmin1Entity, false),
+			integration.PreSetupAddTenantAdmin(t, nil, tenantAdmin2Entity, false),
+		},
+		Name:   "(Super Admin) Success: canImpersonate=false",
+		Method: http.MethodGet,
+		Path:   tenantPath + "?limit=100",
+		Header: integration.AuthHeader(superAdminJWT),
+		Body:   nil,
+
+		WantStatusCode:   http.StatusOK,
+		WantResponseBody: "\"count\":2",
+		ResponseChecks:   []helper.IntegrationTestCheck{},
+		PostSetups: []helper.IntegrationTestPostSetup{
+			integration.PostSetupDeleteTenant(t, tenantId),
+			nil,
+			nil,
+		},
+	})
+
 	// Unauthorized no JWT
 	tests = append(tests, &helper.IntegrationTestCase{
 		PreSetups: []helper.IntegrationTestPreSetup{
@@ -191,29 +214,6 @@ func TestGetTenantAdminListIntegration(t *testing.T) {
 			integration.CheckNoTenant(nonexistentTenantId.String()),
 		},
 		PostSetups: nil,
-	})
-
-	// Unauthorized access: super admin (CanImpersonate=false)
-	tests = append(tests, &helper.IntegrationTestCase{
-		PreSetups: []helper.IntegrationTestPreSetup{
-			integration.PreSetupCreateTenant(tenantId, false),
-			integration.PreSetupAddTenantAdmin(t, nil, tenantAdmin1Entity, false),
-			integration.PreSetupAddTenantAdmin(t, nil, tenantAdmin2Entity, false),
-		},
-		Name:   "Fail (super admin): unauth access (canImpersonate=false)",
-		Method: http.MethodGet,
-		Path:   tenantPath,
-		Header: integration.AuthHeader(superAdminJWT),
-		Body:   nil,
-
-		WantStatusCode:   http.StatusNotFound,
-		WantResponseBody: helper.ErrJsonString(tenant.ErrTenantNotFound),
-		ResponseChecks:   []helper.IntegrationTestCheck{},
-		PostSetups: []helper.IntegrationTestPostSetup{
-			integration.PostSetupDeleteTenant(t, tenantId),
-			nil,
-			nil,
-		},
 	})
 
 	// Unauthorized access: other tenant admin

--- a/backend/tests/user/integrationTests/get_tenant_admin_test.go
+++ b/backend/tests/user/integrationTests/get_tenant_admin_test.go
@@ -81,6 +81,30 @@ func TestGetTenantAdminIntegration(t *testing.T) {
 	}
 	tests = append(tests, &tcSuccess)
 
+	// Success: Super admin when CanImpersonate=false
+	var tcSuperDenied helper.IntegrationTestCase
+	tcSuperDenied = helper.IntegrationTestCase{
+		PreSetups: []helper.IntegrationTestPreSetup{
+			integration.PreSetupCreateTenant(tenant1Id, false),
+			integration.PreSetupAddTenantAdmin(t, &tcSuperDenied, existingTenantAdmin1Entity, true),
+		},
+		Name:   "Success: super admin when CanImpersonate=false",
+		Method: http.MethodGet,
+		Header: integration.AuthHeader(superAdminJWT),
+		Body:   nil,
+
+		WantStatusCode:   http.StatusOK,
+		WantResponseBody: existingEmail1,
+		ResponseChecks: []helper.IntegrationTestCheck{
+			integration.CheckTenantMemberInserted(existingEmail1, tenant1Id.String()),
+		},
+		PostSetups: []helper.IntegrationTestPostSetup{
+			integration.PostSetupDeleteTenant(t, tenant1Id),
+			nil,
+		},
+	}
+	tests = append(tests, &tcSuperDenied)
+
 	// Unauthorized: no JWT
 	var tcNoJwt helper.IntegrationTestCase
 	tcNoJwt = helper.IntegrationTestCase{
@@ -194,28 +218,6 @@ func TestGetTenantAdminIntegration(t *testing.T) {
 		},
 	}
 	tests = append(tests, &tcWrongTenantAdmin)
-
-	// Super admin denied when CanImpersonate=false
-	var tcSuperDenied helper.IntegrationTestCase
-	tcSuperDenied = helper.IntegrationTestCase{
-		PreSetups: []helper.IntegrationTestPreSetup{
-			integration.PreSetupCreateTenant(tenant1Id, false),
-			integration.PreSetupAddTenantAdmin(t, &tcSuperDenied, existingTenantAdmin1Entity, true),
-		},
-		Name:   "Fail: super admin denied when CanImpersonate=false",
-		Method: http.MethodGet,
-		Header: integration.AuthHeader(superAdminJWT),
-		Body:   nil,
-
-		WantStatusCode:   http.StatusNotFound,
-		WantResponseBody: helper.ErrJsonString(tenant.ErrTenantNotFound),
-		ResponseChecks:   []helper.IntegrationTestCheck{integration.CheckTenantMemberInserted(existingEmail1, tenant1Id.String())},
-		PostSetups: []helper.IntegrationTestPostSetup{
-			integration.PostSetupDeleteTenant(t, tenant1Id),
-			nil,
-		},
-	}
-	tests = append(tests, &tcSuperDenied)
 
 	// User not found
 	tests = append(tests, &helper.IntegrationTestCase{

--- a/backend/tests/user/service_create_test.go
+++ b/backend/tests/user/service_create_test.go
@@ -603,6 +603,18 @@ func TestService_CreateTenantAdmin(t *testing.T) {
 			expectedUser:  expectedUser,
 		},
 		{
+			name:  "(Super Admin) Success: impersonation fail",
+			input: inputWith(superAdminRequester),
+			setupSteps: []mockSetupFunc_CreateUserService{
+				step1TenantOk_CannotImpersonate,
+				step2CreateUserOk,
+				step3CreateTokenOk,
+				step4SendEmailOk,
+			},
+			expectedError: nil,
+			expectedUser:  expectedUser,
+		},
+		{
 			name:  "(Tenant Admin) Success: authorized, OK",
 			input: inputWith(authorizedTenantAdminRequester),
 			setupSteps: []mockSetupFunc_CreateUserService{
@@ -636,16 +648,6 @@ func TestService_CreateTenantAdmin(t *testing.T) {
 		},
 
 		// Step 1: test autorizzazione
-		{
-			name:  "(Super Admin) Fail (step 1): impersonation fail",
-			input: inputWith(superAdminRequester),
-			setupSteps: []mockSetupFunc_CreateUserService{
-				step1TenantOk_CannotImpersonate,
-				step3NeverCalled,
-			},
-			expectedError: identity.ErrUnauthorizedAccess,
-			expectedUser:  user.User{},
-		},
 		{
 			name:  "(Tenant Admin) Fail (step 1): unauthorized access",
 			input: inputWith(unauthorizedTenantAdminRequester),

--- a/backend/tests/user/service_delete_test.go
+++ b/backend/tests/user/service_delete_test.go
@@ -508,6 +508,18 @@ func TestService_DeleteTenantAdmin(t *testing.T) {
 			expectedUser:  expectedUser,
 		},
 		{
+			name:  "(Super Admin) Success: delete tenant admin, impersonation fail",
+			input: inputWith(superAdminRequester),
+			setupSteps: []mockSetupFunc_DeleteUserService{
+				step1TenantOk_CannotImpersonate,
+				step2GetUserOk,
+				step3CountOk,
+				step4DeleteUserOk,
+			},
+			expectedError: nil,
+			expectedUser:  expectedUser,
+		},
+		{
 			name:  "(Tenant Admin) Success: delete tenant admin, authorization ok",
 			input: inputWith(authorizedTenantAdminRequester),
 			setupSteps: []mockSetupFunc_DeleteUserService{
@@ -542,16 +554,6 @@ func TestService_DeleteTenantAdmin(t *testing.T) {
 		},
 
 		// Step 1: autorizzazione
-		{
-			name:  "(Super Admin) Fail (step 1 auth): impersonation fail",
-			input: inputWith(superAdminRequester),
-			setupSteps: []mockSetupFunc_DeleteUserService{
-				step1TenantOk_CannotImpersonate,
-				step2NeverCalled,
-			},
-			expectedError: identity.ErrUnauthorizedAccess,
-			expectedUser:  user.User{},
-		},
 		{
 			name:  "(Tenant Admin) Fail (step 1 auth): unauthorized access",
 			input: inputWith(unauthorizedTenantAdminRequester),

--- a/backend/tests/user/service_get_test.go
+++ b/backend/tests/user/service_get_test.go
@@ -370,7 +370,6 @@ func TestService_GetTenantAdmin(t *testing.T) {
 	// Test comportamentali
 	// Step 1: get tenant
 	step1TenantOk_CanImpersonate := newStepTenantOk_GetUserService(targetTenantId, true)
-	step1TenantOk_CannotImpersonate := newStepTenantOk_GetUserService(targetTenantId, false)
 
 	step1TenantFail := newStepTenantNotFound_GetUserService(targetTenantId)
 
@@ -495,16 +494,6 @@ func TestService_GetTenantAdmin(t *testing.T) {
 		},
 
 		// Step 1: autorizzazione
-		{
-			name:  "(Super Admin) Fail (step 1): impersonation fail",
-			input: inputWith(superAdminRequester),
-			setupSteps: []mockSetupFunc_GetUserService{
-				step1TenantOk_CannotImpersonate,
-				step2NeverCalled,
-			},
-			expectedUser:  user.User{},
-			expectedError: identity.ErrUnauthorizedAccess,
-		},
 		{
 			name:  "(Tenant Admin) Fail (step 1): unauthorized access",
 			input: inputWith(unauthorizedTenantAdminRequester),
@@ -1261,6 +1250,17 @@ func TestService_GetTenantAdminsByTenant(t *testing.T) {
 			expectedTotal: expectedTotalCase2,
 			expectedError: nil,
 		},
+		{
+			name:  "(Super Admin) Fail (auth): impersonation failed",
+			input: inputWith(baseInputCase1, superAdminRequester),
+			setupSteps: []mockSetupFunc_GetUserService{
+				step1TenantOk_CannotImpersonate,
+				step2Case1Ok,
+			},
+			expectedUsers: expectedUsersCase1,
+			expectedTotal: expectedTotalCase1,
+			expectedError: nil,
+		},
 
 		// Step 1: get tenant
 		{
@@ -1285,17 +1285,7 @@ func TestService_GetTenantAdminsByTenant(t *testing.T) {
 		},
 
 		// Step 1: autorizzazione
-		{
-			name:  "(Super Admin) Fail (auth): impersonation failed",
-			input: inputWith(baseInputCase1, superAdminRequester),
-			setupSteps: []mockSetupFunc_GetUserService{
-				step1TenantOk_CannotImpersonate,
-				step2NeverCalled,
-			},
-			expectedUsers: nil,
-			expectedTotal: 0,
-			expectedError: identity.ErrUnauthorizedAccess,
-		},
+
 		{
 			name:  "(Tenant Admin) Fail (auth): unauthorized access",
 			input: inputWith(baseInputCase1, unauthorizedTenantAdminRequester),


### PR DESCRIPTION
- Rendere possibile creazione ed eliminazione di Tenant Admin in tenant non impersonabili
- Rendere possibile /get_tenant_admin e /get_tenant_admins in tenant non impersonabile, ma non /get_tenant_users
- Fixati TU e TI

closes #136